### PR TITLE
Revert "Use libdrm from flatpak extension for host daemon"

### DIFF
--- a/drm-path.patch
+++ b/drm-path.patch
@@ -1,83 +1,13 @@
 diff --git a/lact/src/flatpak.rs b/lact/src/flatpak.rs
-index beabca31..abdce357 100644
+index beabca31..a83f5b67 100644
 --- a/lact/src/flatpak.rs
 +++ b/lact/src/flatpak.rs
-@@ -7,6 +7,8 @@ use std::{
-     process::Command,
- };
- 
-+const FLATPAK_GL_EXTENSION: &str = "org.freedesktop.Platform.GL";
-+
- pub fn cmd(cmd: FlatpakCommand) -> anyhow::Result<()> {
-     let info = get_flatpak_info()?;
-     match cmd {
-@@ -15,6 +17,20 @@ pub fn cmd(cmd: FlatpakCommand) -> anyhow::Result<()> {
- }
- 
- fn generate_daemon_cmd(info: &Ini) -> anyhow::Result<()> {
-+    let runtime_name = info
-+        .get("Application", "runtime")
-+        .context("Could not get runtime name")?;
-+    let runtime_name = runtime_name.trim_start_matches("runtime/");
-+
-+    let runtime_architecture = runtime_name
-+        .split('/')
-+        .nth(1)
-+        .context("Could not extract architecture from runtime name")?;
-+
-+    let runtime_commit = info
-+        .get("Instance", "runtime-commit")
-+        .context("Could not extract runtime commit")?;
-+
-     let app_path = info
-         .get("Instance", "app-path")
-         .context("Could not get app path")?;
-@@ -23,6 +39,39 @@ fn generate_daemon_cmd(info: &Ini) -> anyhow::Result<()> {
-         .get("Instance", "runtime-path")
-         .context("Could not get runtime path")?;
- 
-+    let base_runtime_path = runtime_path
-+        .strip_suffix("/files")
-+        .context("Unexpected runtime path format")?;
-+    let runtime_metadata_path = format!("{base_runtime_path}/metadata");
-+
-+    let expected_suffix = format!("/{runtime_name}/{runtime_commit}");
-+    let base_runtimes_path = base_runtime_path
-+        .strip_suffix(&expected_suffix)
-+        .context("Unexpected runtime path format")?;
-+
-+    eprintln!("Reading runtime metadata from {runtime_metadata_path}");
-+
-+    let raw_runtime_metadata = Command::new("flatpak-spawn")
-+        .args(["--host", "cat", &runtime_metadata_path])
-+        .output()
-+        .context("Could not get host runtime metadata")?;
-+
-+    let mut runtime_metadata = Ini::new();
-+    runtime_metadata
-+        .read(String::from_utf8(raw_runtime_metadata.stdout)?)
-+        .map_err(|err| anyhow!("Could not parse runtime metadata: {err}"))?;
-+
-+    let gl_extension_version = runtime_metadata
-+        .get(&format!("Extension {FLATPAK_GL_EXTENSION}"), "versions")
-+        .context("Could not get extension versions")?;
-+    let gl_extension_version = gl_extension_version
-+        .split(";")
-+        .next()
-+        .context("Empty version list")?;
-+
-+    let gl_extension_lib_path = format!("{base_runtimes_path}/{FLATPAK_GL_EXTENSION}.default/{runtime_architecture}/{gl_extension_version}/active/files/lib");
-+    eprintln!("Detected flatpak GL extension at {gl_extension_lib_path}");
-+
-     let relative_ld_path = get_relative_ld_path()?;
-     let relative_ld_path_parts = relative_ld_path.components().collect::<Vec<Component>>();
- 
-@@ -36,7 +85,7 @@ fn generate_daemon_cmd(info: &Ini) -> anyhow::Result<()> {
+@@ -36,7 +36,7 @@ fn generate_daemon_cmd(info: &Ini) -> anyhow::Result<()> {
              .display()
      );
      let app_bin_path = format!("{app_path}/bin");
 -    let library_paths = format!("{app_path}/lib:{runtime_lib_path}");
-+    let library_paths = format!("{app_path}/lib:{gl_extension_lib_path}:{runtime_lib_path}");
++    let library_paths = format!("{app_path}/lib:{app_path}/drm/lib:{runtime_lib_path}");
  
      println!("{ld_path} --library-path {library_paths} {app_bin_path}/lact daemon");
  

--- a/io.github.ilya_zlobintsev.LACT.yaml
+++ b/io.github.ilya_zlobintsev.LACT.yaml
@@ -64,6 +64,20 @@ modules:
           - /share/icons
         modules:
           - shared-modules/intltool/intltool-0.51.json
+      - name: libdrm
+        buildsystem: meson
+        builddir: true
+        config-opts:
+          - -Dtests=false
+          - --libdir=/app/drm/lib
+        sources:
+          - type: archive
+            url: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-2.4.124/drm-libdrm-2.4.124.tar.gz
+            sha256: 49c077f3938147e7c321fe89255eb189c1be68f6ed0aa36e29d38e3db0e84e08
+            x-checker-data:
+              type: anitya
+              project-id: 1596
+              url-template: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-$version/drm-libdrm-$version.tar.gz
 
   - name: vulkan-tools
     buildsystem: cmake-ninja


### PR DESCRIPTION
There are issues with running `flatpak-spawn` from the startup script, reverting this for now until static linking is figured out

This reverts commit 34a227758ee0a6f18d7b12261fffe2b2d07310d9.